### PR TITLE
Update sfnwdl plugin for use outside ECS and with generic WDLs

### DIFF
--- a/sfn-wdl/sfnwdl_miniwdl_plugin.py
+++ b/sfn-wdl/sfnwdl_miniwdl_plugin.py
@@ -45,14 +45,14 @@ def task(cfg, logger, run_id, run_dir, task, **recv):
 
     # pass through certain environment variables expected by idseq-dag
     recv["container"].create_service_kwargs = {
-        "env": [f"{var}={os.environ[var]}" for var in PASSTHROUGH_ENV_VARS],
+        "env": [f"{var}={os.environ[var]}" for var in PASSTHROUGH_ENV_VARS] if var in os.environ,
     }
     # inject command to log `aws sts get-caller-identity` to confirm AWS_CONTAINER_CREDENTIALS_RELATIVE_URI
     # is passed through & effective
-    recv["command"] = (
-        """aws sts get-caller-identity | jq -c '. + {message: "aws sts get-caller-identity"}' 1>&2\n\n"""
-        + recv["command"]
-    )
+    # recv["command"] = (
+    #     """aws sts get-caller-identity | jq -c '. + {message: "aws sts get-caller-identity"}' 1>&2\n\n"""
+    #     + recv["command"]
+    # )
     recv = yield recv
 
     # do nothing with outputs


### PR DESCRIPTION
- Our workflows require the region env var to be set, but AWS_CONTAINER_CREDENTIALS_RELATIVE_URI is not set outside ECS
- Job logs contained errors from `aws sts get-caller-identity` when awscli/jq was not installed in task container

It would be nice to design more for the general use case of needing to pass environment variable based config into the task container. In this case we'd like to error out when AWS_DEFAULT_REGION is not set (mandatory env var) but proceed if AWS_CONTAINER_CREDENTIALS_RELATIVE_URI is not set (optional env var).