### PR TITLE
minimal instrumentation example for SFN-WDL

### DIFF
--- a/sfn-wdl/setup.py
+++ b/sfn-wdl/setup.py
@@ -8,7 +8,7 @@ with open(path.join(path.dirname(__file__), "README.md")) as f:
 
 setup(
     name="sfnwdl-miniwdl-plugin",
-    version="0.0.1",
+    version="0.0.2",
     description="miniwdl plugin for IDseq SFN-WDL customizations",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/sfn-wdl/sfnwdl_miniwdl_plugin.py
+++ b/sfn-wdl/sfnwdl_miniwdl_plugin.py
@@ -16,7 +16,11 @@ PASSTHROUGH_ENV_VARS = (
 def task(cfg, logger, run_id, run_dir, task, **recv):
     t_0 = time.time()
 
-    # do nothing with inputs
+    # First yield point -- through which we'll get the task inputs. Also, the 'task' object is a
+    # WDL.Task through which we have access to the full AST of the task source code.
+    #   https://miniwdl.readthedocs.io/en/latest/WDL.html#WDL.Tree.Task
+    # pending proper documentation for this interface, see the detailed comments in this example:
+    #   https://github.com/chanzuckerberg/miniwdl/blob/main/examples/plugin_task_omnibus/miniwdl_task_omnibus_example.py
     recv = yield recv
 
     # provide a callback for stderr log messages that attempts to parse them as JSON and pass them
@@ -58,6 +62,8 @@ def task(cfg, logger, run_id, run_dir, task, **recv):
     )
     recv = yield recv
 
+    # After task completion -- logging elapsed time in structured form, to be picked up by
+    # CloudWatch Logs. We also have access to the task outputs in recv.
     t_elapsed = time.time() - t_0
     logger.notice(
         _(

--- a/sfn-wdl/sfnwdl_miniwdl_plugin.py
+++ b/sfn-wdl/sfnwdl_miniwdl_plugin.py
@@ -1,5 +1,6 @@
 import os
 import json
+import time
 import WDL
 from WDL._util import StructuredLogMessage as _
 
@@ -13,6 +14,8 @@ PASSTHROUGH_ENV_VARS = (
 
 
 def task(cfg, logger, run_id, run_dir, task, **recv):
+    t_0 = time.time()
+
     # do nothing with inputs
     recv = yield recv
 
@@ -54,6 +57,16 @@ def task(cfg, logger, run_id, run_dir, task, **recv):
         + recv["command"]
     )
     recv = yield recv
+
+    t_elapsed = time.time() - t_0
+    logger.notice(
+        _(
+            "SFN-WDL task done",
+            run_id=run_id[-1],
+            task_name=task.name,
+            elapsed_seconds=round(t_elapsed, 3),
+        )
+    )
 
     # do nothing with outputs
     yield recv


### PR DESCRIPTION
@tfrcarvalho Here's a minimal starting point for custom task instrumentation. It causes a JSON message like the following to be emitted in the SFN-WDL environment, where it's picked up by CloudWatch Logs (probably along with further contextual details about the execution, though we may need to do more -- elaborated below).

```json
{
  "message": "SFN-WDL task done",
  "level": "NOTICE",
  "run_id": "call-hello-2",
  "task_name": "hello",
  "elapsed_seconds": 8.465,
  "timestamp": 1606817738.337,
  "source": "wdl.w:hello_caller.t:call-hello-2",
  "levelno": 25
}
``` 

The code measures the time between points in the task plugin "coroutine" which gets control at a few key moments in the task lifecycle (detailed in [this example](https://github.com/chanzuckerberg/miniwdl/blob/main/examples/plugin_task_omnibus/miniwdl_task_omnibus_example.py)).

Some discussion points:
* Is there enough detail to group/aggregate the collected timings in the ways we want to, by searching for these messages in CloudWatch Logs?
* In particular, the task and run_id (reflecting specific place the task is called in the workflow) are included but not anything identifying the inputs or the "execution." Some identifying information might be added by CloudWatch Logs, we need to check if it's adequate.
* The plugin does have access to all the inputs and outputs, as well as `task.meta` (the arbitrary metadata stanza one can put in the source code), so there are all sorts of details we can add; just need to spec them out after closing the proof-of-concept loop with CloudWatch Logs.