### PR TITLE
create short-read-mngs step status JSON files

### DIFF
--- a/sfn-wdl/README.md
+++ b/sfn-wdl/README.md
@@ -1,6 +1,7 @@
 This miniwdl plugin implements a few customizations for the IDseq SFN-WDL backend which don't quite warrant dedicated packages:
 
 * Parsing JSON log messages from tasks and forwarding them in structured form
+* Writing JSON files with status updates to S3 as the short-read-mngs pipeline executes (formerly created by idseq-dag and consumed by the webapp)
 * Passing through environment variables from runner to tasks (supports ECR credential handling for idseq-dag)
 
 These functions, and any new ones under consideration, should be used sparingly in order to minimize WDL portability impacts.

--- a/sfn-wdl/setup.py
+++ b/sfn-wdl/setup.py
@@ -8,7 +8,7 @@ with open(path.join(path.dirname(__file__), "README.md")) as f:
 
 setup(
     name="sfnwdl-miniwdl-plugin",
-    version="0.0.2",
+    version="0.1.0",
     description="miniwdl plugin for IDseq SFN-WDL customizations",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/sfn-wdl/setup.py
+++ b/sfn-wdl/setup.py
@@ -19,6 +19,10 @@ setup(
     install_requires=["boto3"],
     reentry_register=True,
     entry_points={
+        # NOTE: the step status JSON function of this plugin has to run after the s3upload plugin
+        # (so that the uploads really are complete once sets the status to say so). miniwdl runs
+        # the plugins in alphabetical order, so "sfnwdl_miniwdl_plugin_task" has to follow the
+        # corresponding upload plugin's name(s).
         "miniwdl.plugin.task": ["sfnwdl_miniwdl_plugin_task = sfnwdl_miniwdl_plugin:task"]
     },
 )

--- a/sfn-wdl/sfnwdl_miniwdl_plugin.py
+++ b/sfn-wdl/sfnwdl_miniwdl_plugin.py
@@ -176,7 +176,7 @@ def update_status_json(logger, task, run_ids, s3_wd_uri, entries):
                     "s3",
                     "cp",
                     outfile.name,
-                    os.path.join(s3_wd_uri, f"{workflow_name}_status.json"),
+                    os.path.join(s3_wd_uri, f"{workflow_name}_status2.json"),
                 ]
                 logger.verbose(
                     _("update_status_json", step_name=step_name, status=status, cmd=" ".join(cmd))

--- a/sfn-wdl/sfnwdl_miniwdl_plugin.py
+++ b/sfn-wdl/sfnwdl_miniwdl_plugin.py
@@ -173,7 +173,7 @@ def update_status_json(logger, task, run_ids, s3_wd_uri, entries):
 
             # Upload it
             with tempfile.NamedTemporaryFile() as outfile:
-                outfile.write(json.dumps(_status_json))
+                outfile.write(json.dumps(_status_json).encode())
                 outfile.flush()
                 cmd = [
                     "aws",

--- a/sfn-wdl/sfnwdl_miniwdl_plugin.py
+++ b/sfn-wdl/sfnwdl_miniwdl_plugin.py
@@ -180,7 +180,7 @@ def update_status_json(logger, task, run_ids, s3_wd_uri, entries):
                     "s3",
                     "cp",
                     outfile.name,
-                    os.path.join(s3_wd_uri, f"{workflow_name}_status_NEW.json"),
+                    os.path.join(s3_wd_uri, f"{workflow_name}_status.json"),
                 ]
                 logger.verbose(
                     _("update_status_json", step_name=step_name, status=status, cmd=" ".join(cmd))

--- a/sfn-wdl/sfnwdl_miniwdl_plugin.py
+++ b/sfn-wdl/sfnwdl_miniwdl_plugin.py
@@ -186,7 +186,7 @@ def update_status_json(logger, task, run_ids, s3_wd_uri, entries):
                     _("update_status_json", step_name=step_name, status=status, cmd=" ".join(cmd))
                 )
                 try:
-                    subprocess.run(cmd, capture_output=True, check=True)
+                    subprocess.run(cmd, stderr=subprocess.PIPE, check=True)
                 except subprocess.CalledProcessError as cpe:
                     logger.error(
                         _(

--- a/sfn-wdl/sfnwdl_miniwdl_plugin.py
+++ b/sfn-wdl/sfnwdl_miniwdl_plugin.py
@@ -20,7 +20,7 @@ def task(cfg, logger, run_id, run_dir, task, **recv):
     t_0 = time.time()
 
     s3_wd_uri = recv["inputs"].get("s3_wd_uri", None)
-    if s3_wd_uri:
+    if s3_wd_uri and s3_wd_uri.value:
         s3_wd_uri = s3_wd_uri.value
         update_status_json(
             logger,
@@ -172,7 +172,6 @@ def update_status_json(logger, task, run_ids, s3_wd_uri, entries):
                 status[k] = v
 
             # Upload it
-            logger.debug(_("update_status_json", step_name=step_name, status=status))
             with tempfile.NamedTemporaryFile() as outfile:
                 outfile.write(json.dumps(_status_json))
                 outfile.flush()
@@ -181,8 +180,11 @@ def update_status_json(logger, task, run_ids, s3_wd_uri, entries):
                     "s3",
                     "cp",
                     outfile.name,
-                    os.path.join(s3_wd_uri, f"{workflow_name}_status.json"),
+                    os.path.join(s3_wd_uri, f"{workflow_name}_status_NEW.json"),
                 ]
+                logger.verbose(
+                    _("update_status_json", step_name=step_name, status=status, cmd=" ".join(cmd))
+                )
                 try:
                     subprocess.run(cmd, capture_output=True, check=True)
                 except subprocess.CalledProcessError as cpe:

--- a/sfn-wdl/sfnwdl_miniwdl_plugin.py
+++ b/sfn-wdl/sfnwdl_miniwdl_plugin.py
@@ -102,6 +102,8 @@ def task(cfg, logger, run_id, run_dir, task, **recv):
                 msg = last_stderr_json.get("cause", last_stderr_json["wdl_error_message"])
                 if last_stderr_json.get("error", None) == "InvalidInputFileError":
                     status = "user_errored"
+                if "step_description_md" in last_stderr_json:
+                    status["description"] = last_stderr_json["step_description_md"]
             update_status_json(
                 logger,
                 task,

--- a/sfn-wdl/sfnwdl_miniwdl_plugin.py
+++ b/sfn-wdl/sfnwdl_miniwdl_plugin.py
@@ -164,10 +164,6 @@ def update_status_json(logger, task, run_ids, s3_wd_uri, entries):
         # Update _status_json which is accumulating over the course of workflow execution.
         with _status_json_lock:
             status = _status_json.setdefault(step_name, {})
-
-            status["resources"] = {
-                "IDseq Docs": "https://github.com/chanzuckerberg/idseq-workflows"
-            }
             for k, v in entries.items():
                 status[k] = v
 


### PR DESCRIPTION
Migrate idseq-dag functionality to create/update these JSON files used by the webapp to display pipeline status. A `threading.Lock` in the miniwdl process (loading this plugin) ensures that the status updates for two tasks running concurrently won't interfere with each other.