### PR TITLE
handle directory uploads

### DIFF
--- a/s3upload/miniwdl_s3upload.py
+++ b/s3upload/miniwdl_s3upload.py
@@ -72,7 +72,8 @@ def task(cfg, logger, run_id, run_dir, task, **recv):
             assert os.path.isdir(abs_output)
             output_contents = [os.path.join(abs_output, fn) for fn in os.listdir(abs_output)]
             assert output_contents
-            if len(output_contents) == 1 and os.path.isdir(output_contents[0]):
+            if len(output_contents) == 1 and os.path.isdir(output_contents[0]) and os.path.islink(output_contents[0]):
+                # directory output
                 for (dn, subdirs, files) in os.walk(output_contents[0], onerror=_raise):
                     assert dn == output_contents[0] or dn.startswith(output_contents[0] + "/"), dn
                     for fn in files:
@@ -80,11 +81,13 @@ def task(cfg, logger, run_id, run_dir, task, **recv):
                         s3uri = os.path.join(s3prefix, os.path.relpath(abs_fn, abs_output))
                         upload_file(abs_fn, s3uri)
             elif len(output_contents) == 1:
+                # file output
                 basename = os.path.basename(output_contents[0])
                 abs_fn = os.path.join(abs_output, basename)
                 s3uri = os.path.join(s3prefix, basename)
                 upload_file(abs_fn, s3uri)
             else:
+                # file array output
                 assert all(os.path.basename(abs_fn).isdigit() for abs_fn in output_contents), output_contents
                 for index_dir in output_contents:
                     fns = os.listdir(index_dir)

--- a/s3upload/miniwdl_s3upload.py
+++ b/s3upload/miniwdl_s3upload.py
@@ -75,7 +75,7 @@ def task(cfg, logger, run_id, run_dir, task, **recv):
             assert output_contents
             if len(output_contents) == 1 and os.path.isdir(output_contents[0]) and os.path.islink(output_contents[0]):
                 # directory output
-                _uploaded_directories[output_contents[0]] = os.path.join(s3prefix, output) + "/"
+                _uploaded_directories[output] = os.path.join(s3prefix, output) + "/"
                 for (dn, subdirs, files) in os.walk(output_contents[0], onerror=_raise):
                     assert dn == output_contents[0] or dn.startswith(output_contents[0] + "/"), dn
                     for fn in files:

--- a/s3upload/miniwdl_s3upload.py
+++ b/s3upload/miniwdl_s3upload.py
@@ -75,7 +75,7 @@ def task(cfg, logger, run_id, run_dir, task, **recv):
             assert output_contents
             if len(output_contents) == 1 and os.path.isdir(output_contents[0]) and os.path.islink(output_contents[0]):
                 # directory output
-                _uploaded_directories[output_contents[0]] = os.path.join(s3prefix, output)
+                _uploaded_directories[output_contents[0]] = os.path.join(s3prefix, output) + "/"
                 for (dn, subdirs, files) in os.walk(output_contents[0], onerror=_raise):
                     assert dn == output_contents[0] or dn.startswith(output_contents[0] + "/"), dn
                     for fn in files:

--- a/s3upload/miniwdl_s3upload.py
+++ b/s3upload/miniwdl_s3upload.py
@@ -145,7 +145,7 @@ def write_outputs_s3_json(logger, outputs, run_dir, s3prefix, namespace):
         return fn
 
     with _uploaded_files_lock:
-        outputs_s3 = WDL.Value.rewrite_env_files(outputs, rewriter)
+        outputs_s3 = WDL.Value.rewrite_env_paths(outputs, rewriter)
 
     # get json dict of rewritten outputs
     outputs_s3_json = WDL.values_to_json(outputs_s3, namespace=namespace)

--- a/s3upload/miniwdl_s3upload.py
+++ b/s3upload/miniwdl_s3upload.py
@@ -131,14 +131,14 @@ def workflow(cfg, logger, run_id, run_dir, workflow, **recv):
 
 def write_outputs_s3_json(logger, outputs, run_dir, s3prefix, namespace):
     # rewrite uploaded files to their S3 URIs
-    def rewriter(fn):
+    def rewriter(fd):
         try:
-            return _uploaded_files[inode(fn)]
+            return _uploaded_files[inode(fd.value)]
         except Exception:
             logger.warning(
                 _(
-                    "output file wasn't uploaded to S3; keeping local path in outputs.s3.json",
-                    file=fn,
+                    "output file or directory wasn't uploaded to S3; keeping local path in outputs.s3.json",
+                    path=fd.value,
                 )
             )
             return fn

--- a/s3upload/miniwdl_s3upload.py
+++ b/s3upload/miniwdl_s3upload.py
@@ -132,17 +132,17 @@ def workflow(cfg, logger, run_id, run_dir, workflow, **recv):
 
 def write_outputs_s3_json(logger, outputs, run_dir, s3prefix, namespace):
     # rewrite uploaded files to their S3 URIs
-    def rewriter(fn):
-        s3_path = _uploaded_files.get(inode(fn.value)) or _uploaded_directories.get(fn.value)
+    def rewriter(obj):
+        s3_path = _uploaded_files.get(inode(obj.value)) or _uploaded_directories.get(obj.value)
         if s3_path:
             return s3_path
         logger.warning(
             _(
                 "output file wasn't uploaded to S3; keeping local path in outputs.s3.json",
-                file=fn,
+                path=obj.value,
             )
         )
-        return fn
+        return obj.value
 
     with _uploaded_files_lock:
         outputs_s3 = WDL.Value.rewrite_env_paths(outputs, rewriter)

--- a/s3upload/miniwdl_s3upload.py
+++ b/s3upload/miniwdl_s3upload.py
@@ -133,7 +133,7 @@ def workflow(cfg, logger, run_id, run_dir, workflow, **recv):
 def write_outputs_s3_json(logger, outputs, run_dir, s3prefix, namespace):
     # rewrite uploaded files to their S3 URIs
     def rewriter(fn):
-        s3_path = _uploaded_files.get(inode(fn)) or _uploaded_directories.get(fn)
+        s3_path = _uploaded_files.get(inode(fn.value)) or _uploaded_directories.get(fn.value)
         if s3_path:
             return s3_path
         logger.warning(

--- a/s3upload/miniwdl_s3upload.py
+++ b/s3upload/miniwdl_s3upload.py
@@ -179,4 +179,3 @@ def s3cp(logger, fn, s3uri):
 def inode(link):
     st = os.stat(os.path.realpath(link))
     return (st.st_dev, st.st_ino)
-

--- a/s3upload/miniwdl_s3upload.py
+++ b/s3upload/miniwdl_s3upload.py
@@ -65,7 +65,7 @@ def task(cfg, logger, run_id, run_dir, task, **recv):
                 # upload to S3
                 abs_fn = os.path.join(dn, fn)
                 # s3uri = os.path.join(s3prefix, *run_id[1:], dn[(len(links_dir) + 1) :], fn)
-                s3uri = os.path.join(s3prefix, os.path.basename(fn))
+                s3uri = os.path.join(s3prefix, os.path.relpath(abs_fn, links_dir))
                 s3cp(logger, abs_fn, s3uri)
                 # record in _uploaded_files (keyed by inode, so that it can be found from any
                 # symlink or hardlink)

--- a/s3upload/miniwdl_s3upload.py
+++ b/s3upload/miniwdl_s3upload.py
@@ -75,7 +75,7 @@ def task(cfg, logger, run_id, run_dir, task, **recv):
             assert output_contents
             if len(output_contents) == 1 and os.path.isdir(output_contents[0]) and os.path.islink(output_contents[0]):
                 # directory output
-                _uploaded_directories[output] = os.path.join(s3prefix, output) + "/"
+                _uploaded_directories[output_contents[0]] = os.path.join(s3prefix, output) + "/"
                 for (dn, subdirs, files) in os.walk(output_contents[0], onerror=_raise):
                     assert dn == output_contents[0] or dn.startswith(output_contents[0] + "/"), dn
                     for fn in files:

--- a/s3upload/setup.py
+++ b/s3upload/setup.py
@@ -8,7 +8,7 @@ with open(path.join(path.dirname(__file__), "README.md")) as f:
 
 setup(
     name="miniwdl-s3upload",
-    version="0.0.5",
+    version="0.0.6",
     description="miniwdl plugin for progressive upload of task output files to Amazon S3",
     url="https://github.com/chanzuckerberg/miniwdl-s3upload",
     project_urls={


### PR DESCRIPTION
There is a strong chance you won't like this, I am iffy about it myself. This handles directory uploads.

The challenge I had was dealing with the three types of file outputs and their expected upload behavior (as far as I know there are only three):
- File outputs: which we want uploaded to their base name (ex `out/my-file-output/my-file-output.txt` -> `s3://my-bucket/my-wd/my-file-output.txt`)
- File array outputs: which we want each file uploaded to it's basename (ex `out/my-array-output/0/zeroth-output.txt` -> `s3://my-bucket/my-wd/zeroth-output.txt`)
- Directory outputs: which we want each file uploaded to it's path relative to the directory output (ex `out/my-directory-output/foo.txt` -> `s3://my-bucket/my-wd/my-directory-output/foo.txt`)

Since the array output and the directory output both use the directories under the main output directory differently I needed to explicitly recognize the output type of each output. At first I tried to do this by processing the outputs from the task but I felt this was overly complicated. The outputs follow a predictable pattern and I think it is more straightforward to recognize it. File outputs have a single file at the in their output directories, array outputs have one or more directories with integer names at the top level, and directory outputs have a single link directory.

I specifically opted not to use s3parcp's recursive functionality to more easily slot into your caching mechanism. I don't think it will impact performance at all and it is simpler.

I tested this on my use case and it worked.