### PR TITLE
Add back proper last log

### DIFF
--- a/sfn-wdl/sfnwdl_miniwdl_plugin.py
+++ b/sfn-wdl/sfnwdl_miniwdl_plugin.py
@@ -1,4 +1,4 @@
-rousettes import os
+import os
 import json
 import time
 import threading


### PR DESCRIPTION
I am not totally sure if this will fix the issue but in some cases the error information is not being added to the wdl output as it should be. I think this is happening because there are additional logs added after it in this new logic. This is less of a thing I intend to merge and more of a PR to explain my thinking on this bug.