### PR TITLE
Fix issues in sfn-wdl plugin

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -28,7 +28,7 @@ jobs:
     - name: miniwdl --version
       run: miniwdl --version
     - name: flake8
-      run: flake8
+      run: flake8 ${{ matrix.which_plugin }}
     - name: mypy
-      run: mypy --ignore-missing-imports --exclude setup.py .
+      run: mypy --ignore-missing-imports ${{ matrix.which_plugin }}
     # TODO: tests

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -21,11 +21,14 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install miniwdl
-      run: pip install miniwdl
+    - name: Install miniwdl and test dependencies
+      run: pip install miniwdl flake8 mypy
     - name: Install plugin
       run: pip install -e ${{ matrix.which_plugin }}
     - name: miniwdl --version
       run: miniwdl --version
+    - name: flake8
+      run: flake8
+    - name: mypy
+      run: mypy --ignore-missing-imports --exclude setup.py .
     # TODO: tests
-

--- a/sfn-wdl/sfnwdl_miniwdl_plugin.py
+++ b/sfn-wdl/sfnwdl_miniwdl_plugin.py
@@ -3,6 +3,7 @@ import json
 import time
 import threading
 import re
+from typing import Dict, Any
 
 import boto3
 
@@ -138,7 +139,7 @@ def task(cfg, logger, run_id, run_dir, task, **recv):
     yield recv
 
 
-_status_json = {}
+_status_json: Dict[str, Any] = {}
 _status_json_lock = threading.Lock()
 
 


### PR DESCRIPTION
This is a follow-up to #9.

The operative changes are:
- Correct bug in assembling status dict in error branch
- When uploading status file, use an in-process boto3 client instead of the AWS CLI.

I installed flake8 and mypy in CI in the hopes of catching this stuff in the future, but to my dismay mypy doesn't pick up on the type mismatch 😞 

Tested by installing this branch on dev via shellcode update and verifying it correctly forwards error metadata.