### PR TITLE
s3upload: ignore dotfiles under out/

### DIFF
--- a/s3upload/miniwdl_s3upload.py
+++ b/s3upload/miniwdl_s3upload.py
@@ -70,7 +70,7 @@ def task(cfg, logger, run_id, run_dir, task, **recv):
         for output in os.listdir(links_dir):
             abs_output = os.path.join(links_dir, output)
             assert os.path.isdir(abs_output)
-            output_contents = [os.path.join(abs_output, fn) for fn in os.listdir(abs_output)]
+            output_contents = [os.path.join(abs_output, fn) for fn in os.listdir(abs_output) if not fn.startswith(".")]
             assert output_contents
             if len(output_contents) == 1 and os.path.isdir(output_contents[0]) and os.path.islink(output_contents[0]):
                 # directory output
@@ -91,7 +91,7 @@ def task(cfg, logger, run_id, run_dir, task, **recv):
                 # file array output
                 assert all(os.path.basename(abs_fn).isdigit() for abs_fn in output_contents), output_contents
                 for index_dir in output_contents:
-                    fns = os.listdir(index_dir)
+                    fns = [fn for fn in os.listdir(index_dir) if not fn.startswith(".")]
                     assert len(fns) == 1
                     abs_fn = os.path.join(index_dir, fns[0])
                     s3uri = os.path.join(s3prefix, fns[0])

--- a/s3upload/setup.py
+++ b/s3upload/setup.py
@@ -8,7 +8,7 @@ with open(path.join(path.dirname(__file__), "README.md")) as f:
 
 setup(
     name="miniwdl-s3upload",
-    version="0.0.6",
+    version="0.0.7",
     description="miniwdl plugin for progressive upload of task output files to Amazon S3",
     url="https://github.com/chanzuckerberg/miniwdl-s3upload",
     project_urls={

--- a/s3upload/test/test.sh
+++ b/s3upload/test/test.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Quick plugin test. Assumes desired version of miniwdl is already installed. Installs plugin
+# locally and runs a test workflow with file and directory outputs. The invoking shell must have
+# MINIWDL__S3_PROGRESSIVE_UPLOAD__URI_PREFIX set to an appropriate test location, and a suitable
+# AWS role configured for uploading there. Also, you must have s3parcp available in PATH.
+#
+# Example invocation from miniwdl-plugins/ (substitute your own S3 bucket):
+# MINIWDL__S3_PROGRESSIVE_UPLOAD__URI_PREFIX=s3://idseq-samples-mlin/s3upload_test s3upload/test/test.sh --verbose
+
+set -eo pipefail
+
+if [[ -z $MINIWDL__S3_PROGRESSIVE_UPLOAD__URI_PREFIX ]]; then
+    >&2 echo "MINIWDL__S3_PROGRESSIVE_UPLOAD__URI_PREFIX required"
+    exit 1
+fi
+aws sts get-caller-identity
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+miniwdl check test/test.wdl
+pip3 install .
+
+miniwdl run test/test.wdl names=Alice names=Bob --dir "$(mktemp -d /tmp/miniwdl_s3upload_test.XXXXXXXX)/." $@
+
+aws s3 ls --recursive "$MINIWDL__S3_PROGRESSIVE_UPLOAD__URI_PREFIX"

--- a/s3upload/test/test.wdl
+++ b/s3upload/test/test.wdl
@@ -1,0 +1,54 @@
+version development
+
+workflow s3upload_test {
+    input {
+        Array[String] names
+    }
+    scatter (name in names) {
+        call hello {
+            input:
+            name = name
+        }
+    }
+    call file_array_to_directory {
+        input:
+        files = hello.message
+    }
+    output {
+        File message0 = hello.message[0]
+        Array[File] messages_array = hello.message
+        Directory messages_directory = file_array_to_directory.directory
+    }
+}
+
+task hello {
+    input {
+        String name
+    }
+    command <<<
+        echo "Hello, ~{name}!" > "~{name}.txt"
+    >>>
+    output {
+        File message = "~{name}.txt"
+    }
+    runtime {
+        docker: "ubuntu:20.04"
+    }
+}
+
+task file_array_to_directory {
+    input {
+        Array[File] files
+    }
+    File filenames = write_lines(files)
+    command <<<
+        mkdir messages
+        xargs -i cp -n {} messages/ < "~{filenames}"
+    >>>
+    output {
+        Directory directory = "messages"
+    }
+    runtime {
+        docker: "ubuntu:20.04"
+    }
+}


### PR DESCRIPTION
@kislyuk This is the minimal diff for the plugin to make it compatible with the latest versions of miniwdl that touch some dotfiles under the `out/` directory. Added a manual test script too (it's not straightforward to automate since it needs to upload into S3).

I would like to generally rework this section of the plugin code, but have foregone that for now to minimize the risk while this is blocking the version upgrade. The current version @morsecodist and I worked out while trying different ways to make Directory uploads work, and the purpose of the new dotfiles was to allow simpler logic (but in fact broke the current logic)