### PR TITLE
call caching proposal

### DIFF
--- a/s3upload/miniwdl_s3upload.py
+++ b/s3upload/miniwdl_s3upload.py
@@ -85,7 +85,7 @@ def inode(link: str):
     return (st.st_dev, st.st_ino)
 
 
-_uploaded_files = {}
+_uploaded_files: Dict[Tuple[int, int], str] = {}
 _cached_files: Dict[Tuple[int, int], Tuple[str, Env.Bindings[Value.Base]]] = {}
 _uploaded_files_lock = threading.Lock()
 
@@ -126,7 +126,7 @@ class CallCache(cache.CallCache):
         with _uploaded_files_lock:
             for o in outputs:
                 if isinstance(o, Value.File):
-                    _cached_files[inode(o.value)] = (key, outputs)
+                    _cached_files[inode(str(o.value))] = (key, outputs)
             cache_put(self._cfg, self._logger, key, outputs)
 
 

--- a/s3upload/setup.py
+++ b/s3upload/setup.py
@@ -27,5 +27,6 @@ setup(
     entry_points={
         'miniwdl.plugin.task': ['s3_progressive_upload_task = miniwdl_s3upload:task'],
         'miniwdl.plugin.workflow': ['s3_progressive_upload_workflow = miniwdl_s3upload:workflow'],
+        'miniwdl.plugin.cache_backend': ['s3_progressive_upload_call_cache_backend = miniwdl_s3upload:CallCache'],
     }
 )


### PR DESCRIPTION
This is a simple call caching implementation that adds an s3 call cache to the s3upload plugin. There are two elements here: the uploader plugin that uploads outputs, and the cache that caches outputs. This plugin adds the s3 path to the call cache files and uploads them to S3. One wrinkle is we only want to add a cache file if the file has been uploaded but this process is multi-threaded so we can't guarantee order. The way I solved this problem is by defining a cache put function that is called from within a shared lock. When called, it checks if all of the files have been uploaded, and if so it uploads the cache file. This is called after each upload and after the cache call. So if the cache is called after all uploads then the cache call uploads the cache. Otherwise the final upload will write to the cache. 

Also I noticed we were uploading all outputs, not just final outputs. So I updated it to upload final outputs normally and only upload intermediate outputs if call caching is enabled with this cache backend. It adds intermediate files with a tag so a bucket lifecycle policy can expire them. I tested this with swipe's mock infra tests and it works.