### PR TITLE
Make s3parcp_download's temp dir configurable.

### DIFF
--- a/s3parcp_download/miniwdl_s3parcp.py
+++ b/s3parcp_download/miniwdl_s3parcp.py
@@ -33,8 +33,9 @@ def main(cfg, logger, uri, **kwargs):
     aws_credentials = "\n".join(f"export {k}='{v}'" for (k, v) in aws_credentials.items())
 
     # write them to a temp file that'll self-destruct automatically
+    temp_dir = cfg["s3parcp"].get("dir", "/mnt")
     with tempfile.NamedTemporaryFile(
-        prefix="miniwdl_download_s3parcp_credentials_", delete=True, mode="w", dir="/mnt"
+        prefix="miniwdl_download_s3parcp_credentials_", delete=True, mode="w", dir=temp_dir
     ) as aws_credentials_file:
         print(aws_credentials, file=aws_credentials_file, flush=True)
         # make file group-readable to ensure it'll be usable if the docker image runs as non-root


### PR DESCRIPTION
I'm working on making Swipe's shared-volume base directory configurable, and this plugin had a hardcoded path. This makes the configuration optional with a default to the previous behavior.