### PR TITLE
use checksums by default

### DIFF
--- a/s3parcp_download/miniwdl_s3parcp.py
+++ b/s3parcp_download/miniwdl_s3parcp.py
@@ -74,7 +74,7 @@ task s3parcp {
         mkdir __out
         cd __out
         # allocating one hardware thread to two concurrent part xfers
-        s3parcp -c ~{cpu*2} "~{uri}" .
+        s3parcp --checksum -c ~{cpu*2} "~{uri}" .
     >>>
 
     output {

--- a/s3upload/miniwdl_s3upload.py
+++ b/s3upload/miniwdl_s3upload.py
@@ -278,10 +278,7 @@ _s3parcp_lock = threading.Lock()
 
 def s3cp(logger, fn, s3uri):
     with _s3parcp_lock:
-        if "S3PARCP_S3_URL" not in os.environ:
-            cmd = ["s3parcp", "--checksum", fn, s3uri]
-        else:
-            cmd = ["s3parcp", fn, s3uri]
+        cmd = ["s3parcp", "--checksum", fn, s3uri]
         logger.debug(" ".join(cmd))
         rslt = subprocess.run(cmd, stderr=subprocess.PIPE)
         if rslt.returncode != 0:
@@ -293,4 +290,4 @@ def s3cp(logger, fn, s3uri):
                     stderr=rslt.stderr.decode("utf-8"),
                 )
             )
-            raise WDL.Error.RuntimeError("failed: " + " ".join(cmd) + ", " + rslt.stderr.decode("utf-8"))
+            raise WDL.Error.RuntimeError("failed: " + " ".join(cmd))

--- a/s3upload/miniwdl_s3upload.py
+++ b/s3upload/miniwdl_s3upload.py
@@ -276,7 +276,7 @@ _s3parcp_lock = threading.Lock()
 
 def s3cp(logger, fn, s3uri):
     with _s3parcp_lock:
-        cmd = ["s3parcp", fn, s3uri]
+        cmd = ["s3parcp", "--checksum", fn, s3uri]
         logger.debug(" ".join(cmd))
         rslt = subprocess.run(cmd, stderr=subprocess.PIPE)
         if rslt.returncode != 0:

--- a/s3upload/miniwdl_s3upload.py
+++ b/s3upload/miniwdl_s3upload.py
@@ -293,4 +293,4 @@ def s3cp(logger, fn, s3uri):
                     stderr=rslt.stderr.decode("utf-8"),
                 )
             )
-            raise WDL.Error.RuntimeError("failed: " + " ".join(cmd))
+            raise WDL.Error.RuntimeError("failed: " + " ".join(cmd) + ", " + rslt.stderr.decode("utf-8"))

--- a/s3upload/miniwdl_s3upload.py
+++ b/s3upload/miniwdl_s3upload.py
@@ -60,10 +60,9 @@ def get_s3_put_prefix(cfg: config.Loader) -> str:
 
 
 def get_s3_get_prefix(cfg: config.Loader) -> str:
-    # s3prefix = cfg["s3_progressive_upload"].get("call_cache_get_uri_prefix")
-    s3prefix = None
-    if not s3prefix:
+    if not cfg.has_option("s3_progressive_upload", "uri_prefix"):
         return get_s3_put_prefix(cfg)
+    s3prefix = cfg["s3_progressive_upload"].get("call_cache_get_uri_prefix")
     assert s3prefix.startswith("s3://"), "MINIWDL__S3_PROGRESSIVE_UPLOAD__CALL_CACHE_GET_URI_PREFIX invalid"
     return s3prefix
 
@@ -110,7 +109,7 @@ def cache_put(cfg: config.Loader, logger: logging.Logger, key: str, outputs: Env
         return _uploaded_files[inode(str(v.value))]
 
     remapped_outputs = Value.rewrite_env_paths(outputs, cache)
-    if not missing:
+    if not missing and cfg.has_option("s3_progressive_upload", "uri_prefix"):
         uri = os.path.join(get_s3_put_prefix(cfg), "cache", f"{key}.json")
         s3_object(uri).put(Body=json.dumps(values_to_json(remapped_outputs)).encode())
         flag_temporary(uri)

--- a/s3upload/miniwdl_s3upload.py
+++ b/s3upload/miniwdl_s3upload.py
@@ -278,7 +278,10 @@ _s3parcp_lock = threading.Lock()
 
 def s3cp(logger, fn, s3uri):
     with _s3parcp_lock:
-        cmd = ["s3parcp", "--checksum", fn, s3uri]
+        if "S3PARCP_S3_URL" in os.environ:
+            cmd = ["s3parcp", "--checksum", fn, s3uri]
+        else:
+            cmd = ["s3parcp", fn, s3uri]
         logger.debug(" ".join(cmd))
         rslt = subprocess.run(cmd, stderr=subprocess.PIPE)
         if rslt.returncode != 0:

--- a/s3upload/miniwdl_s3upload.py
+++ b/s3upload/miniwdl_s3upload.py
@@ -278,7 +278,7 @@ _s3parcp_lock = threading.Lock()
 
 def s3cp(logger, fn, s3uri):
     with _s3parcp_lock:
-        if "S3PARCP_S3_URL" in os.environ:
+        if "S3PARCP_S3_URL" not in os.environ:
             cmd = ["s3parcp", "--checksum", fn, s3uri]
         else:
             cmd = ["s3parcp", fn, s3uri]

--- a/s3upload/miniwdl_s3upload.py
+++ b/s3upload/miniwdl_s3upload.py
@@ -120,6 +120,8 @@ class CallCache(cache.CallCache):
     def get(
         self, key: str, inputs: Env.Bindings[Value.Base], output_types: Env.Bindings[Type.Base]
     ) -> Optional[Env.Bindings[Value.Base]]:
+        if not self._cfg.has_option("s3_progressive_upload", "uri_prefix"):
+            return super().get(key, inputs, output_types)
         uri = urlparse(get_s3_get_prefix(self._cfg))
         bucket, prefix = uri.hostname, uri.path
 

--- a/s3upload/miniwdl_s3upload.py
+++ b/s3upload/miniwdl_s3upload.py
@@ -60,7 +60,8 @@ def get_s3_put_prefix(cfg: config.Loader) -> str:
 
 
 def get_s3_get_prefix(cfg: config.Loader) -> str:
-    s3prefix = cfg["s3_progressive_upload"].get("call_cache_get_uri_prefix")
+    # s3prefix = cfg["s3_progressive_upload"].get("call_cache_get_uri_prefix")
+    s3prefix = None
     if not s3prefix:
         return get_s3_put_prefix(cfg)
     assert s3prefix.startswith("s3://"), "MINIWDL__S3_PROGRESSIVE_UPLOAD__CALL_CACHE_GET_URI_PREFIX invalid"

--- a/s3upload/miniwdl_s3upload.py
+++ b/s3upload/miniwdl_s3upload.py
@@ -60,7 +60,7 @@ def get_s3_put_prefix(cfg: config.Loader) -> str:
 
 
 def get_s3_get_prefix(cfg: config.Loader) -> str:
-    if not cfg.has_option("s3_progressive_upload", "uri_prefix"):
+    if not cfg.has_option("s3_progressive_upload", "call_cache_get_uri_prefix"):
         return get_s3_put_prefix(cfg)
     s3prefix = cfg["s3_progressive_upload"].get("call_cache_get_uri_prefix")
     assert s3prefix.startswith("s3://"), "MINIWDL__S3_PROGRESSIVE_UPLOAD__CALL_CACHE_GET_URI_PREFIX invalid"


### PR DESCRIPTION
With the new checksums we can use this every time, if there is no checksum while downloading a warning will print but it will still work.