### PR TITLE
Adding support for local subprocess backend

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,6 +1,8 @@
 name: Python package
 
-on: [push]
+on:
+  workflow_dispatch:
+  push:
 
 jobs:
   build:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -14,6 +14,7 @@ jobs:
           - s3parcp_download
           - s3upload
           - sfn-wdl
+          - subprocess
 
     steps:
     - uses: actions/checkout@v1
@@ -32,3 +33,9 @@ jobs:
     - name: mypy
       run: mypy --ignore-missing-imports ${{ matrix.which_plugin }}
     # TODO: tests
+    - name: Run subprocess test
+      if: ${{ matrix.which_plugin == 'subprocess' }}
+      env:
+        MINIWDL__SCHEDULER__CONTAINER_BACKEND: subprocess
+      run: |
+        miniwdl run_self_test

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
         which_plugin:
           - s3parcp_download
           - s3upload

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       max-parallel: 4
       matrix:

--- a/subprocess/README.md
+++ b/subprocess/README.md
@@ -1,0 +1,9 @@
+# miniwdl subprocess plugin
+This miniwdl plugin implements a backend for executing WDL tasks on
+the local system using subprocesses.
+
+To configure miniwdl to use local processes:
+
+1. Set the environment variable `MINIWDL__SCHEDULER__CONTAINER_BACKEND=subprocess` or the equivalent [configuration file](https://miniwdl.readthedocs.io/en/latest/runner_reference.html#configuration) option `[scheduler] container_backend=subprocess`
+2. install aria2 using `apt-get install aria2` or `brew install aria2`
+3. Test the configuration with `miniwdl run_self_test`

--- a/subprocess/miniwdl_subprocess.py
+++ b/subprocess/miniwdl_subprocess.py
@@ -26,7 +26,7 @@ class LocalSubprocess(SubprocessBase):
 
     @property
     def cli_name(self) -> str:
-        return "local"
+        return "subprocess
 
     @property
     def cli_exe(self) -> List[str]:

--- a/subprocess/miniwdl_subprocess.py
+++ b/subprocess/miniwdl_subprocess.py
@@ -1,0 +1,44 @@
+# NOTE: this file is excluded from coverage analysis since alternate container backends may not be
+#       available in the CI environment. To test locally: prove -v tests/singularity.t
+import os
+import logging
+from typing import List
+from contextlib import ExitStack
+from WDL.runtime import config
+from WDL.runtime.backend.cli_subprocess import SubprocessBase
+from typing import ContextManager
+
+
+class LocalSubprocess(SubprocessBase):
+    """
+    local task runtime based on cli_subprocess.SubprocessBase
+    """
+
+    @classmethod
+    def global_init(cls, cfg: config.Loader, logger: logging.Logger) -> None:
+        cfg.override({"file_io": {"copy_input_files": True}})
+        logger.notice("Local runtime initialized (BETA)")
+
+    def __init__(self, cfg: config.Loader, run_id: str, host_dir: str) -> None:
+        super().__init__(cfg, run_id, host_dir)
+        self.container_dir = self.host_dir
+        # self.host_dir = os.path.join(self.host_dir, "work")
+
+    @property
+    def cli_name(self) -> str:
+        return "local"
+
+    @property
+    def cli_exe(self) -> List[str]:
+        return self.cfg.get_list("singularity", "exe")
+
+    def _pull(self, logger: logging.Logger, cleanup: ExitStack) -> str:
+        pass
+
+    def _run_invocation(self, logger: logging.Logger, cleanup: ExitStack, image: str) -> List[str]:
+        self.host_dir = os.path.join(self.host_dir, "work")
+        return []
+
+    def task_running_context(self) -> ContextManager[None]:
+        self.host_dir = self.container_dir
+        return super().task_running_context()

--- a/subprocess/miniwdl_subprocess.py
+++ b/subprocess/miniwdl_subprocess.py
@@ -26,7 +26,7 @@ class LocalSubprocess(SubprocessBase):
 
     @property
     def cli_name(self) -> str:
-        return "subprocess
+        return "subprocess"
 
     @property
     def cli_exe(self) -> List[str]:

--- a/subprocess/miniwdl_subprocess.py
+++ b/subprocess/miniwdl_subprocess.py
@@ -17,7 +17,7 @@ class LocalSubprocess(SubprocessBase):
     @classmethod
     def global_init(cls, cfg: config.Loader, logger: logging.Logger) -> None:
         cfg.override({"file_io": {"copy_input_files": True}})
-        logger.notice("Local runtime initialized (BETA)")
+        logger.info("Local runtime initialized (BETA)")
 
     def __init__(self, cfg: config.Loader, run_id: str, host_dir: str) -> None:
         super().__init__(cfg, run_id, host_dir)
@@ -33,7 +33,7 @@ class LocalSubprocess(SubprocessBase):
         return self.cfg.get_list("singularity", "exe")
 
     def _pull(self, logger: logging.Logger, cleanup: ExitStack) -> str:
-        pass
+        return ''
 
     def _run_invocation(self, logger: logging.Logger, cleanup: ExitStack, image: str) -> List[str]:
         self.host_dir = os.path.join(self.host_dir, "work")

--- a/subprocess/setup.py
+++ b/subprocess/setup.py
@@ -19,6 +19,6 @@ setup(
     install_requires=[],
     reentry_register=True,
     entry_points={
-        "miniwdl.plugin.container_backend": ["local = miniwdl_subprocess:LocalSubprocess"]
+        "miniwdl.plugin.container_backend": ["subprocess = miniwdl_subprocess:LocalSubprocess"]
     },
 )

--- a/subprocess/setup.py
+++ b/subprocess/setup.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+from setuptools import setup
+from os import path
+
+this_directory = path.abspath(path.dirname(__file__))
+with open(path.join(path.dirname(__file__), "README.md")) as f:
+    long_description = f.read()
+
+setup(
+    name="local-miniwdl-plugin",
+    version="0.0.1",
+    description="miniwdl plugin for running tasks locally without using containers",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    author="Bernd Höhl",
+    py_modules=["miniwdl_subprocess"],
+    python_requires=">=3.6",
+    setup_requires=["reentry"],
+    install_requires=[],
+    reentry_register=True,
+    entry_points={
+        "miniwdl.plugin.container_backend": ["local = miniwdl_subprocess:LocalSubprocess"]
+    },
+)


### PR DESCRIPTION
miniwdl currently does only support container based backends.
For local testing and maybe other cases I find it usefull to have a version that does not require containers.
This pull request adds the ability to run commands using just plain subprocesses.
It ignores pulling images and requires the commands to execute to be installed.
Btw. cromwell also supports running without containers, but to me it is far slower than miniwdl.
If you find it usefull, please merge and publish a package.
Thanks
Bernd